### PR TITLE
When running, only remove applications which you are deploying

### DIFF
--- a/mule-esb-plugin/src/main/java/org/mule/tooling/esb/launcher/configuration/runner/MuleRunnerCommandLine.java
+++ b/mule-esb-plugin/src/main/java/org/mule/tooling/esb/launcher/configuration/runner/MuleRunnerCommandLine.java
@@ -139,15 +139,24 @@ public class MuleRunnerCommandLine extends JavaCommandLineState implements MuleR
 
         boolean clearData = isClearAppData();
 
-        try {
-            FileUtils.cleanDirectory(apps);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
         Module[] modules = model.getModules();
 
         for (Module m : modules) {
+            File[] moduleFiles = apps.listFiles(x -> x.getName().startsWith(m.getName()));
+            if(moduleFiles != null && moduleFiles.length > 0){
+                for(File file: moduleFiles){
+                    try {
+                        if(file.isDirectory()){
+                            FileUtils.cleanDirectory(file);
+                        } else {
+                            FileUtils.forceDelete(file);
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
             if (clearData) {
                 File moduleAppData = new File(muleAppData, m.getName());
                 FileUtil.delete(moduleAppData);


### PR DESCRIPTION
When running mule via IntelliJ, it was removing all deployed applications when you press run.
Now it only removes the applications which you trying to deploy a new version of